### PR TITLE
refactor: remove deprecated functions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import inquirer from "inquirer";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as T from "fp-ts/lib/Task";
 import * as E from "fp-ts/lib/Either";
-import { pipe } from "fp-ts/lib/pipeable";
+import { flow, pipe } from "fp-ts/lib/function";
 import { CliConfig } from "./models/CliConfig";
 
 function parseArgumentsIntoOptions(rawArgs: string[]): Partial<CliConfig> {
@@ -96,8 +96,6 @@ function promptForMissingOptions(
   );
 }
 
-function cli(args: string[]): TE.TaskEither<Error, CliConfig> {
-  return pipe(args, parseArgumentsIntoOptions, promptForMissingOptions);
-}
+const cli = flow(parseArgumentsIntoOptions, promptForMissingOptions);
 
 export { cli };

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -2,9 +2,8 @@
 import { Swagger, Property } from "./models/Swagger";
 import * as E from "fp-ts/lib/Either";
 import * as A from "fp-ts/lib/Array";
-import { pipe } from "fp-ts/lib/pipeable";
 import { Options } from "./models/Options";
-import { flow, identity, constant } from "fp-ts/lib/function";
+import { flow, identity, constant, pipe } from "fp-ts/lib/function";
 import { doIf, prefix, replace } from "./services/utils";
 import {
   isReference,
@@ -27,7 +26,7 @@ import { codecGenerator } from "./generators/codecGenerator";
 
 type TypeResult = E.Either<Error, string>;
 
-const traverseArray = A.array.traverse(E.either);
+const traverseArray = A.Traversable.traverse(E.Applicative);
 
 function getGenerator({ type }: Options): Generator<unknown> {
   return {
@@ -232,12 +231,9 @@ function getTypesFromSchemas(options: Options) {
   return function(schemas: {
     [key: string]: Property;
   }): E.Either<Error, string[]> {
-    return pipe(
-      traverseArray(Object.entries(schemas), ([key, property]) =>
-        pipe(
-          getType(options)(property),
-          E.map(getGenerator(options).getTypeDefinition(key))
-        )
+    return traverseArray(Object.entries(schemas), ([key, property]) =>
+      E.map(getGenerator(options).getTypeDefinition(key))(
+        getType(options)(property)
       )
     );
   };

--- a/src/generators/codecGenerator.ts
+++ b/src/generators/codecGenerator.ts
@@ -1,5 +1,4 @@
 import { flow } from "fp-ts/lib/function";
-import { pipe } from "fp-ts/lib/pipeable";
 import { Generator } from "../models/Generator";
 import {
   doIfElse,
@@ -24,8 +23,7 @@ const getIntersection = doIfElse(
   flow(join(","), surround("t.intersection([", "])"))
 );
 
-const getKey = (key: string): string =>
-  pipe(key, surround('"', '"'), suffix(":"));
+const getKey = flow(surround('"', '"'), suffix(":"));
 
 const getType = flow(join(","), surround("t.type({", "})"));
 

--- a/src/generators/flowGenerator.ts
+++ b/src/generators/flowGenerator.ts
@@ -1,5 +1,5 @@
-import { constant, flow, not } from "fp-ts/lib/function";
-import { pipe } from "fp-ts/lib/pipeable";
+import { constant, flow, pipe } from "fp-ts/lib/function";
+import { not } from "fp-ts/lib/Predicate";
 import { Generator } from "../models/Generator";
 import {
   doIf,

--- a/src/generators/typescriptGenerator.ts
+++ b/src/generators/typescriptGenerator.ts
@@ -1,5 +1,5 @@
-import { constant, flow, not } from "fp-ts/lib/function";
-import { pipe } from "fp-ts/lib/pipeable";
+import { constant, flow, pipe } from "fp-ts/lib/function";
+import { not } from "fp-ts/lib/Predicate";
 import { Generator } from "../models/Generator";
 import {
   doIf,

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,6 +1,6 @@
 import * as TE from "fp-ts/lib/TaskEither";
 import * as E from "fp-ts/lib/Either";
-import { pipe } from "fp-ts/lib/pipeable";
+import { pipe } from "fp-ts/lib/function";
 import { getSwagger } from "./read";
 import { generate } from "./generate";
 import { write } from "./write";

--- a/src/read.ts
+++ b/src/read.ts
@@ -6,7 +6,7 @@ import path from "path";
 import * as IE from "fp-ts/lib/IOEither";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as E from "fp-ts/lib/Either";
-import { pipe } from "fp-ts/lib/pipeable";
+import { pipe } from "fp-ts/lib/function";
 import { Swagger, Schemas } from "./models/Swagger";
 import { doIf, patch, doIfElse } from "./services/utils";
 import { constant } from "fp-ts/lib/function";

--- a/src/write.ts
+++ b/src/write.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import prettier from "prettier";
 import * as TE from "fp-ts/lib/TaskEither";
-import { pipe } from "fp-ts/lib/pipeable";
+import { flow } from "fp-ts/lib/function";
 
 function prettify(types: string): string {
   return prettier.format(types);
@@ -16,10 +16,9 @@ function writeToFile(filename: string) {
   };
 }
 
-function write(filename: string) {
-  return function(types: string): TE.TaskEither<Error, void> {
-    return pipe(types, prettify, writeToFile(filename));
-  };
+function write(
+  filename: string
+): (types: string) => TE.TaskEither<Error, void> {
+  return flow(prettify, writeToFile(filename));
 }
-
 export { write };


### PR DESCRIPTION
With latest `fp-ts` updates some functions has been deprecated. Goal of this PR is to remove the deprecated functions.
Some info: https://stackoverflow.com/a/67875549/657582