### PR TITLE
fix: convert any string to pascal case

### DIFF
--- a/src/services/__tests__/utils.test.ts
+++ b/src/services/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { patch } from "../utils";
+import { patch, toPascalCase } from "../utils";
 
 describe("patch", () => {
   describe("when the patch contains an existing property", () => {
@@ -135,5 +135,18 @@ describe("patch", () => {
         }
       });
     });
+  });
+});
+
+describe("toPascalCase", () => {
+  test("it should convert any string to PascalCase", () => {
+    expect(toPascalCase("test-string")).toBe("TestString");
+    expect(toPascalCase("test_string")).toBe("TestString");
+    expect(toPascalCase("test string")).toBe("TestString");
+    expect(toPascalCase("test.string")).toBe("TestString");
+    expect(toPascalCase("testString")).toBe("TestString");
+    expect(toPascalCase("TestString")).toBe("TestString");
+    expect(toPascalCase("Multiple_test-string")).toBe("MultipleTestString");
+    expect(toPascalCase("multiple.test String")).toBe("MultipleTestString");
   });
 });

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -83,7 +83,7 @@ export function replace(searchValue: string, replaceValue: string) {
 }
 
 export const toPascalCase = flow(
-  split("-"),
+  (s: string) => s.match(/[a-zA-Z0-9]+/g) || [],
   map(token => token[0].toUpperCase() + token.slice(1)),
   join("")
 );


### PR DESCRIPTION
## Description
If I try to generate types for this king of swagger: https://gist.github.com/GabriMcNab/22b190988b050122fda1cad5d46fdca2

I get this output:
```ts
"use strict";
export type Error = { code?: string; message?: string };
export type Title = string;
export type Description = string;
export type Highlights = Array<string>;
export type Included = Array<string>;
export type Non_included = Array<string>;
export type Important_information = Array<string>;
export type Info_voucher = string;
export type Id = string;
export type Go_commercial = boolean;
export type Asterix_id = string;
export type Core_id = string;
export type Creation_date = string;
export type Updated_date = string;
export type Functional_raw = {
  asterix_id?: Asterix_id;
  core_id?: Core_id;
  highlights?: Highlights;
  included?: Included;
  non_included?: Non_included;
  important_information?: Important_information;
};
export type Commercial_raw = {
  title: Title;
  description?: Description;
  info_voucher?: Info_voucher;
};
export type Raw_element = {
  id?: Id;
  go_commercial?: Go_commercial;
  creation_date?: Creation_date;
  updated_date?: Updated_date;
  functional?: Functional_raw;
  commercial: Commercial_raw;
};
```
Which is not compliant with the PascalCase standard for Typescript.

## What
- Changed `toPascalCase` function logic to support multiple case tipe

## Why
The `toPascalCase` function should be able to convert any kind of case (snake_case, kebab-case, camelCase) to PascalCase.